### PR TITLE
moving to 0.9.0 release of doomsday

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -89,9 +89,9 @@ instance_groups:
 
 releases:
 - name:    doomsday
-  version: 0.8.1
-  url:     https://github.com/doomsday-project/doomsday-boshrelease/releases/download/v0.8.1/doomsday-0.8.1.tgz
-  sha1:    d228ec6bed298fd70850c56180e32a47c09d78fd
+  version: 0.9.0
+  url:     https://github.com/doomsday-project/doomsday-boshrelease/releases/download/v0.9.0/doomsday-0.9.0.tgz
+  sha1:    bd066be11570de9689dd47519352dcde20cb8982
 
 stemcells:
 - alias: default


### PR DESCRIPTION
## Changes proposed in this pull request:

- Move doomsday to 0.9.0 release for new features (already done manually)

## Security considerations

None
