### PR TITLE
bosh deployment doesn't need to be fetched

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -61,7 +61,6 @@ jobs:
       # this is just to trigger a deployment, the manifest specifies latest.
       - get: xenial-stemcell
         trigger: true
-      - get: doomsday
       - get: doomsday-deployment-src
         passed:
         - reconfigure


### PR DESCRIPTION
## Changes proposed in this pull request:

Fetching the resource can cause deployments to fail when the deployment identifier gets out of sync. The get step is unnecessary.

The pipeline is currently hung up for this reason.

## Security considerations

None
