### PR TITLE
adding backend for prod url checks

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -73,6 +73,11 @@ instance_groups:
           hosts: ((master.hosts))
         type: tlsclient
         refresh_internal: 1
+      - name: prod-urls
+        properties:
+          hosts: ((prod.hosts))
+        type: tlsclient
+        refresh_internal: 1
       notifications:
         backend:
           properties:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Added section for prod url checks

## Security considerations

Keep tabs on external prod endpoints so we don't miss expiring Let's Encrypt Certs
