### PR TITLE
update to use hardened images

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -27,9 +27,31 @@ resource_types:
       tag: latest
 
   - name: bosh-deployment
-    type: docker-image
+    type: registry-image
     source:
-      repository: cloudfoundry/bosh-deployment-resource
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: bosh-deployment-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: bosh-io-stemcell
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: bosh-io-stemcell-resource
+      aws_region: us-gov-west-1
+      tag: latest
+
+  - name: git
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
 resources:
   - name: jammy-stemcell


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update resource_types to use hardened images

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updates pipeline to use hardened images
